### PR TITLE
Add requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=["mutesync"],
     zip_safe=True,
     platforms="any",
-    install_requires=list(val.strip() for val in open("requirements.txt")),
+    install_requires=["aiohttp", "async-timeout"],
     classifiers=[
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",


### PR DESCRIPTION
The implemented solution doesn't work as the `requirements.txt` is not shipped in the source tarball that is available on PyPI.

```bash
Traceback (most recent call last):
  File "nix_run_setup", line 8, in <module>
    exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
  File "setup.py", line 18, in <module>
    install_requires=list(val.strip() for val in open("requirements.txt")),
FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
```

Also, `async-timeout` is a [runtime requirement](https://github.com/currentoor/pymutesync/blob/master/mutesync/__init__.py#L7).